### PR TITLE
disable signing on Linux

### DIFF
--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -59,7 +59,6 @@ jobs:
           - group: DotNet-Symbol-Server-Pats
           - _SignType: real
           - _officialBuildArgs: -publish
-                                /p:DotNetSignType=$(_SignType)
                                 /p:TeamName=$(_TeamName)
                                 /p:OfficialBuildId=$(Build.BuildNumber)
                                 /p:DotNetPublishUsingPipelines=true
@@ -67,6 +66,7 @@ jobs:
                                 /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
           - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
             - _signingArgs: -sign
+                            /p:DotNetSignType=$(_SignType)
 
       steps:
       - checkout: self


### PR DESCRIPTION
Arcade signing is failing on Linux.
```
  make[1]: Leaving directory '/__w/1/s/src/msquic/build/linux/x86_openssl'
  /usr/local/bin/cmake -E cmake_progress_start /__w/1/s/src/msquic/build/linux/x86_openssl/CMakeFiles 0
  [06/30/2021 16:15:16] Done.
/__w/1/s/.packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21311.3/tools/Sign.proj(34,5): error : List of files to sign is empty. Make sure that ItemsToSign is configured correctly.
##[error].packages/microsoft.dotnet.arcade.sdk/6.0.0-beta.21311.3/tools/Sign.proj(34,5): error : List of files to sign is empty. Make sure that ItemsToSign is configured correctly.

```