### PR TITLE
update msquic packaging

### DIFF
--- a/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
+++ b/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
@@ -17,17 +17,21 @@
         <ItemGroup>
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\x86_Release_schannel\msquic.dll"
-                PackagePath="runtimes/win10-x86/native/"/>
+                IsNative="true"
+                PackagePath="runtimes/win-x86/native/"/>
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\x86_Release_schannel\msquic.pdb"
-                PackagePath="runtimes/win10-x86/native/"/>
+                IsNative="true"
+                PackagePath="runtimes/win-x86/native/"/>
 
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\x64_Release_schannel\msquic.dll"
-                PackagePath="runtimes/win10-x64/native/"/>
+                IsNative="true"
+                PackagePath="runtimes/win-x64/native/"/>
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\x64_Release_schannel\msquic.pdb"
-                PackagePath="runtimes/win10-x64/native/"/>
+                IsNative="true"
+                PackagePath="runtimes/win-x64/native/"/>
         </ItemGroup>
     </Target>
 


### PR DESCRIPTION
- Add IsNative flag to see if the helps with runtime linker error.
- updated path to match runtime's outputRid e.g. win10 -> win