### PR TITLE
Call make-package on Linux

### DIFF
--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -48,6 +48,7 @@ jobs:
 
         - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
           - _buildScript: ./build.sh
+          - _outputPath: ../../artifacts/packages/${{ parameters.osGroup }}/${{ parameters.archType }}_$(_BuildConfig)_openssl
 
         - _testBuildArg: ''
         - ${{ if eq(parameters.runTests, true) }}:
@@ -83,4 +84,10 @@ jobs:
                 $(_signingArgs)
                 $(_officialBuildArgs)
                 /p:TargetPlatform=${{ parameters.archType }}
-        displayName: Build and Test
+        displayName: Build and Publish
+
+      - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+        - script: ./scripts/make-packages.sh -o $(_outputPath)
+          displayName: Publish
+          workingDirectory: src/msquic
+


### PR DESCRIPTION
This calls the linux package make script, the packages are created in: `src/msquic/artifacts/packages/linux/x64_Release_openssl/`

Not sure what to do with the result ATM.