### PR TITLE
Publish linux artifacts

### DIFF
--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -15,7 +15,7 @@ jobs:
     helixRepo: dotnet/runtimelab
     pool: ${{ parameters.pool }}
     enablePublishBuildArtifacts: true
-    enablePublishBuildAssets: ${{ eq(parameters.osGroup, 'Windows_NT') }}
+    enablePublishBuildAssets: true
     enablePublishUsingPipelines: true
     enableMicrobuild: true
     graphFileGeneration:


### PR DESCRIPTION
Shot at publishing linux artifacts.

We're now producing linux packages in `artifacts/packages/Linux/x64_Release_openssl/*`. I'm not sure how to publish them to CI artifacts with the whole Arcade she-bang. Is there some automagic (what I'm trying here) or should we do it "manually"?

And we're running in container for Linux.

cc: @safern @wfurt 