### PR TITLE
Bootstrap 3.21 CMake

### DIFF
--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -73,9 +73,8 @@ jobs:
       - checkout: self
         submodules: recursive
 
-      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
-        - pwsh: .\eng\addCmakeToPath.ps1
-          displayName: Add CMake to path
+      - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
+        displayName: Install native dependencies
 
       - script: $(_buildScript)
                 -ci

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -73,8 +73,9 @@ jobs:
       - checkout: self
         submodules: recursive
 
-      - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
-        displayName: Install native dependencies
+      - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+        - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
+          displayName: Install native dependencies
 
       - script: $(_buildScript)
                 -ci

--- a/global.json
+++ b/global.json
@@ -7,6 +7,9 @@
   "tools": {
     "dotnet": "6.0.100-preview.4.21255.9"
   },
+  "native-tools": {
+    "cmake": "3.21.0"
+  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21311.3"
   }


### PR DESCRIPTION
msquic depends on >= 3.20 cmake, and currently visual studio 2019 images we provide in internal build have less than this.

_(EDIT:  After deeper investigation, this repo was directly downloading and installing 3.18;  since this is an "arcade-ified" repo I used its native-tool bootstrapping features to get Cmake 3.21.)_