### PR TITLE
Reclassify runtime dependency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <!-- Set this property to false if you don't want to use the runtime
           framework version defined in Versions.props -->
     <UseCustomRuntimeVersion>false</UseCustomRuntimeVersion>
-    <RuntimeFrameworkVersion Condition="$(UseCustomRuntimeVersion)">$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="$(UseCustomRuntimeVersion)">$(MicrosoftNETCoreAppRuntimewinx64Version)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,8 +4,8 @@
     <FrameworkReference Update="Microsoft.NETCore.App"
                         Condition="'$(UseCustomRuntimeVersion)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
                         TargetFramework="$(TargetFramework)"
-                        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppVersion)"
-                        TargetingPackVersion="$(MicrosoftNETCoreAppVersion)" />
+                        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64Version)"
+                        TargetingPackVersion="$(MicrosoftNETCoreAppRefVersion)" />
   </ItemGroup>
 
   <Import Condition="'$(IsTestProject)' == 'true'" Project="$(RepositoryEngineeringDir)testing\runsettings.targets" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App" Version="6.0.0-alpha.1.20514.9">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d67cc2cceb4dc8ecd15f5b6663d93f79de3954fd</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21311.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>4a2b475948d498b89fedef7cf890883f49bc1ea3</Sha>
+    </Dependency>
+    <!-- For use when building against a custom TFM -->
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rc.1.21417.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>61075fbe0d25668b4fa98aa80c2d6c004cf70afd</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-rc.1.21417.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>61075fbe0d25668b4fa98aa80c2d6c004cf70afd</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,8 @@
     <UseVSTestRunner>true</UseVSTestRunner>
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Libs -->
-    <MicrosoftNETCoreAppVersion>6.0.0-alpha.1.20612.4</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreAppRuntimewinx64Version>6.0.0-rc.1.21417.4</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftNETCoreAppRefVersion>6.0.0-rc.1.21417.4</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETTestSdkVersion>16.9.0-preview-20201201-01</MicrosoftNETTestSdkVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>


### PR DESCRIPTION
The runtime dependency is inactive by default today. The runtime framework version is not overridden unless UseCustomRuntimeVersion is true, which it is not. I believe this is from when we didn't have a .NET 6 TFM targeting SDK, and needed to use a custom framework version. That said, the usage is incorrect at the moment because:
- It doesn't take into account a ref pack that drifts from the runtime pack version.
- Microsoft.NETCore.App is no longer actually a package. Instead should be the x64 runtime pack version, as commonly used in other repos.

It also doesn't need to be a product dependency, so reclassifying as a toolset dep.