### PR TITLE
remove preview tag from 6.0 release branch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>Latest</LangVersion>
     <IsPackable>true</IsPackable>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
+    <PreReleaseVersionIteration></PreReleaseVersionIteration>
 
     <!-- Set this property to false if you don't want to use the runtime
           framework version defined in Versions.props -->


### PR DESCRIPTION
one more try. I merged the change to work branch. 
Eventually fixed with https://github.com/dotnet/msquic/pull/61

