### PR TITLE
Remove VersionPrefix so that it is inferred

### DIFF
--- a/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
+++ b/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <OutputType>Library</OutputType>
         <TargetFramework>net6.0</TargetFramework>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <IsPackable>true</IsPackable>
         <IsShipping>false</IsShipping>
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-        <VersionPrefix>6.0.0</VersionPrefix>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Remove the VersionPrefix property so that it is inferred from the Versions.props ProductVersion.

I'm also changing the feeds to that the transport package now pushes into the dotnet7-transport feed instead of dotnet6-transport.