### PR TITLE
Switch to 1ES R&D pools on release 6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>Latest</LangVersion>
     <IsPackable>true</IsPackable>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>7</PreReleaseVersionIteration>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
+    <PreReleaseVersionIteration></PreReleaseVersionIteration>
 
     <!-- Set this property to false if you don't want to use the runtime
           framework version defined in Versions.props -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>Latest</LangVersion>
     <IsPackable>true</IsPackable>
-    <PreReleaseVersionLabel></PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
 
     <!-- Set this property to false if you don't want to use the runtime

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -57,8 +57,8 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           vmImage: 'windows-2019'
@@ -74,8 +74,8 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Ubuntu.1804.Amd64
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           vmImage: 'ubuntu-18.04'

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -61,14 +61,14 @@ stages:
           queue: BuildPool.Windows.10.Amd64.VS2019
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          vmImage: 'windows-latest'
-          
+          vmImage: 'windows-2019'
+
   - template: /eng/pipelines/templates/build-job.yml
     parameters:
       osGroup: Linux
       archType: x64
       runTests: false
-      container: 
+      container:
         registry: mcr
         image: ubuntu-18.04-msquic-20210813173420-e5ef247
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
The same change as https://github.com/dotnet/msquic/pull/48 but for release/6.0 branch