### PR TITLE
Switch to 1ES R&D pools on relrease 6.0

### DIFF
--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -57,8 +57,8 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           vmImage: 'windows-2019'
@@ -74,8 +74,8 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Ubuntu.1804.Amd64
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
The same change as #48 but for release/6.0 branch