### PR TITLE
add ARM64 pipeline

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,32 @@
 <Project>
+  <PropertyGroup Label="CalculateTargetOS">
+    <_hostOS>Linux</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">OSX</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('NETBSD'))">NetBSD</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('ILLUMOS'))">illumos</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('SOLARIS'))">Solaris</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">windows</_hostOS>
+    <HostOS>$(_hostOS)</HostOS>
+    <TargetOS Condition="'$(TargetOS)' == ''">$(_hostOS)</TargetOS>
+  </PropertyGroup>
+
+  <PropertyGroup Label="CalculateArch">
+    <_hostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</_hostArch>
+    <BuildArchitecture Condition="'$(BuildArchitecture)' == ''">$(_hostArch)</BuildArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'arm'">arm</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'armv6'">armv6</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'armel'">armel</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'arm64'">arm64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'loongarch64'">loongarch64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 's390x'">s390x</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(_hostArch)' == 'ppc64le'">ppc64le</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and ('$(TargetOS)' == 'Browser' or '$(RuntimeIdentifier)' == 'browser-wasm')">wasm</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(TargetsMobile)' == 'true'">x64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
+    <Platform Condition="'$(Platform)' == '' and '$(InferPlatformFromTargetArchitecture)' == 'true'">$(TargetArchitecture)</Platform>
+  </PropertyGroup>
+
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -62,7 +62,7 @@ stages:
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           vmImage: 'windows-latest'
-          
+
   - template: /eng/pipelines/templates/build-job.yml
     parameters:
       osGroup: Linux
@@ -79,6 +79,20 @@ stages:
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           vmImage: 'ubuntu-18.04'
+
+  - template: /eng/pipelines/templates/build-job.yml
+    parameters:
+      osGroup: Linux
+      archType: arm64
+      runTests: false
+      pool:
+        name: NetCore1ESPool-Public
+        demands: ImageOverride -equals build.ubuntu.1804.amd64.open
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        isOfficialBuild: true
+        pool:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals build.ubuntu.1804.amd64
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -54,6 +54,7 @@ jobs:
           - OPENSSL_ROOT_DIR: /usr/local/opt/openssl@1.1
 
         - _testBuildArg: ''
+        - _docker: ''
         - ${{ if eq(parameters.runTests, true) }}:
           - _testBuildArg: -test
 
@@ -71,33 +72,36 @@ jobs:
           - ${{ if eq(parameters.osGroup, 'Windows') }}:
             - _signingArgs: -sign
                             /p:DotNetSignType=$(_SignType)
+        - _buildargs: -ci -c $(_BuildConfig) $(_testBuildArg) $(_signingArgs) $(_officialBuildArgs) /p:TargetArchitecture=${{ parameters.archType }}
+        - ${{ if eq(parameters.archType, 'arm64') }}:
+          - _buildScript: docker run --platform linux/arm64 --volume $BUILD_REPOSITORY_LOCALPATH:/msquic -t mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-arm64v8-20220803130954-bfcd90a bash -c "apt-get update && apt-get install -y wget curl liblttng-ust-dev && curl -L -o /tmp/pwsh.tgz https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/powershell-7.2.5-linux-arm64.tar.gz && tar xfz /tmp/pwsh.tgz -C /usr/local/bin/ && curl -o /tmp/cmake.tgz  https://cmake.org/files/v3.23/cmake-3.23.1-linux-aarch64.tar.gz && tar xfz /tmp/cmake.tgz --strip 1  -C /usr/local/ && /msquic/build.sh  -ci -c $(_BuildConfig) $(_testBuildArg) $(_signingArgs) $(_officialBuildArgs) /p:TargetArchitecture=${{ parameters.archType }}"
+          - _buildargs: ''
 
       steps:
       - checkout: self
         submodules: recursive
 
+      - ${{ if eq(parameters.archType, 'arm64') }}:
+        - script: sudo apt-get update && sudo apt-get install -y qemu binfmt-support qemu-user-static docker ruby-dev
+        - script: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes 
+          displayName: Setup QEMU
+
       - ${{ if eq(parameters.osGroup, 'Windows') }}:
         - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
           displayName: Install native dependencies
 
-      - ${{ if eq(parameters.osGroup, 'macOS') }}:
+      - ${{ if or(eq(parameters.osGroup, 'macOS'), eq(parameters.archType, 'arm64')) }}:
         # use cmake from Brew (that may be different)
-        - script:  sed -i .ORI '/cmake/d'  global.json
+        - script:  sed -i.ORI '/cmake/d'  global.json
           displayName: Remove cmake for macOS
-        - script: gem install fpm
+        - script: sudo gem install fpm
           displayName: Install fpm
 
-      - script: $(_buildScript)
-                -ci
-                -c $(_BuildConfig)
-                $(_testBuildArg)
-                $(_signingArgs)
-                $(_officialBuildArgs)
-                /p:TargetPlatform=${{ parameters.archType }}
-        displayName: Build and Publish
+      - script: $(_buildScript) $(_buildargs)
+        displayName: Build binaries
 
       - ${{ if ne(parameters.osGroup, 'Windows') }}:
-        - script: ./scripts/make-packages.sh -output $(_outputPath)
+        - script: ../../make-packages.sh -arch ${{ parameters.archType }} -config $(_BuildConfig) -output $(_outputPath)
           displayName: Make Unix packages
           workingDirectory: src/msquic
 

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -54,7 +54,6 @@ jobs:
           - OPENSSL_ROOT_DIR: /usr/local/opt/openssl@1.1
 
         - _testBuildArg: ''
-        - _docker: ''
         - ${{ if eq(parameters.runTests, true) }}:
           - _testBuildArg: -test
 

--- a/make-packages.sh
+++ b/make-packages.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+usage()
+{
+    echo "Usage: $0 [-output <directory>] [-config Debug]"
+    exit 1
+}
+
+OS=$(uname)
+ARCH=$(uname -m)
+PKGARCH=${ARCH}
+FPM=`which fpm` 2>/dev/null
+CONFIG=Release
+NAME=libmsquic
+CONFLICTS=
+DESCRIPTION="Microsoft implementation of the IETF QUIC protocol"
+VENDOR="Microsoft"
+MAINTAINER="Microsoft QUIC Team <quicdev@microsoft.com>"
+VER_MAJOR=$(cat ./src/inc/msquic.ver | grep 'define VER_MAJOR'| cut -d ' ' -f 3)
+VER_MINOR=$(cat ./src/inc/msquic.ver | grep 'define VER_MINOR'| cut -d ' ' -f 3)
+VER_PATCH=$(cat ./src/inc/msquic.ver | grep 'define VER_PATCH'| cut -d ' ' -f 3)
+
+if [ -z "$FPM" ]; then
+  echo Install 'fpm'
+  exit 1
+fi
+
+if [ "$OS" == 'Linux' ]; then
+    OS=linux
+    LIBEXT=so
+    if [ "$ARCH" == 'x86_64' ]; then
+        ARCH='x64'
+        LIBDIR="lib64"
+    else
+        LIBDIR="lib"
+        if [ "$ARCH" == "aarch64" ]; then
+            ARCH=arm64
+        else
+            if [ "$ARCH" == "armv7l" ]; then
+                ARCH=arm
+            else
+                ARCH=x86
+            fi
+        fi
+    fi
+else
+  if [ "$OS" == 'Darwin' ]; then
+    OS=macos
+    ARCH=x64
+    LIBEXT=dylib
+  else
+    echo Only Linux and macOS packaging is supported at the moment.
+    exit 1
+  fi
+fi
+
+# process arguments and allow to override default values
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | tr "[:upper:]" "[:lower:]")"
+    case $lowerI in
+        -a|-arch|--arch)
+            shift
+            ARCH=$1
+            if [ "$ARCH" == 'arm64' ]; then
+                PKGARCH=aarch64
+            fi
+            ;;
+        -d|-debug|--debug)
+            CONFIG=Debug
+            ;;
+        -config|--config)
+            shift
+            CONFIG=$1
+            ;;
+        -o|-output|--output)
+            shift
+            OUTPUT=$1
+            ;;
+       -\?|-h|--help)
+            usage
+            exit 1
+            ;;
+        *)
+            echo unknown argument
+            ;;
+    esac
+
+    shift
+done
+
+if [ ${CONFIG} != 'Release' ]; then
+  NAME=libmsquic-debug
+  CONFLICTS='libmsquic'
+else
+  CONFLICTS='libmsquic-debug'
+fi
+
+ARTIFACTS="artifacts/bin/${OS}/${ARCH}_${CONFIG}_openssl"
+
+if [ -z ${OUTPUT} ]; then
+    OUTPUT="artifacts/packages/${OS}/${ARCH}_${CONFIG}_openssl"
+fi
+
+mkdir -p ${OUTPUT}
+
+if [ "$OS" == "linux" ]; then
+  # Create symlink
+  ln -s "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" "${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}"
+
+  # RedHat/CentOS
+  FILES="${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
+  FILES="${FILES} ${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}"
+  if [ -e "$ARTIFACTS/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" ]; then
+     FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
+  fi
+  fpm \
+    --force \
+    --input-type dir \
+    --output-type rpm \
+    --architecture ${PKGARCH} \
+    --name ${NAME} \
+    --provides ${NAME} \
+    --conflicts ${CONFLICTS} \
+    --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
+    --description "${DESCRIPTION}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --package "${OUTPUT}" \
+    --license MIT \
+    --url https://github.com/microsoft/msquic \
+    --log error \
+    ${FILES}
+
+  # Debian/Ubuntu
+  if [ "$ARCH" == 'x64' ]; then
+      LIBDIR="lib/x86_64-linux-gnu"
+  fi
+  if [ "$ARCH" == 'arm64' ];then
+    LIBDIR="lib/aarch64-linux-gnu"
+  fi
+  if [ "$ARCH" == 'arm' ];then
+    LIBDIR="lib/arm-linux-gnueabihf"
+  fi
+
+  FILES="${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
+  FILES="${FILES} ${ARTIFACTS}/libmsquic.${LIBEXT}.${VER_MAJOR}=/usr/${LIBDIR}/libmsquic.${LIBEXT}.${VER_MAJOR}"
+  if [ -e "$ARTIFACTS/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}" ]; then
+     FILES="${FILES} ${ARTIFACTS}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}=/usr/${LIBDIR}/libmsquic.lttng.${LIBEXT}.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
+  fi
+  fpm \
+    --force \
+    --input-type dir \
+    --output-type deb \
+    --architecture ${PKGARCH} \
+    --name ${NAME} \
+    --provides ${NAME} \
+    --conflicts ${CONFLICTS} \
+    --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
+    --description "${DESCRIPTION}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --package "${OUTPUT}" \
+    --license MIT \
+    --url https://github.com/microsoft/msquic \
+    --log error \
+    ${FILES}
+fi
+
+# macOS
+if [ "$OS" == "macos" ]; then
+  fpm \
+    --force \
+    --input-type dir \
+    --output-type osxpkg \
+    --name ${NAME} \
+    --provides ${NAME} \
+    --conflicts ${CONFLICTS} \
+    --version ${VER_MAJOR}.${VER_MINOR}.${VER_PATCH} \
+    --description "${DESCRIPTION}" \
+    --vendor "${VENDOR}" \
+    --maintainer "${MAINTAINER}" \
+    --package "${OUTPUT}" \
+    --license MIT \
+    --url https://github.com/microsoft/msquic \
+    --log error \
+    "$ARTIFACTS/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib"=/usr/local/lib/libmsquic.${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}.dylib
+fi

--- a/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
+++ b/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
@@ -14,27 +14,28 @@
     <Target Name="_AddBuildOutputToPackageCore" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
         <ItemGroup>
             <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x86_Release_schannel\msquic.dll"
+                Include="..\msquic\artifacts\bin\windows\x86_$(Configuration)_schannel\msquic.dll"
                 PackagePath="runtimes/win10-x86/native/"/>
             <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x86_Release_schannel\msquic.pdb"
+                Include="..\msquic\artifacts\bin\windows\x86_$(Configuration)_schannel\msquic.pdb"
                 PackagePath="runtimes/win10-x86/native/"/>
 
             <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x64_Release_schannel\msquic.dll"
+                Include="..\msquic\artifacts\bin\windows\x64_$(Configuration)_schannel\msquic.dll"
                 PackagePath="runtimes/win10-x64/native/"/>
             <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x64_Release_schannel\msquic.pdb"
+                Include="..\msquic\artifacts\bin\windows\x64_$(Configuration)_schannel\msquic.pdb"
                 PackagePath="runtimes/win10-x64/native/"/>
         </ItemGroup>
     </Target>
 
     <Target Name="Build-native" AfterTargets="Build">
-        <Exec
-            Command="pwsh scripts/build.ps1 -Config Release -Arch x64 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
+        <Exec IgnoreStandardErrorWarningFormat="true"
+            Command="pwsh scripts/build.ps1 --Parallel 1 -Config $(Configuration) -Arch $(TargetArchitecture) $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
             WorkingDirectory="../msquic"/>
+        <!-- Legacy reasons. Should be fixed.  -->
         <Exec
-            Command="pwsh scripts/build.ps1 -Config Release -Arch x86 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
-            WorkingDirectory="../msquic"/>
+            Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch x86 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
+            WorkingDirectory="../msquic" Condition="'$(TargetOS)' == 'windows'"/>
     </Target>
 </Project>


### PR DESCRIPTION
This adds ARM64 build using X86 machine. 
This PR is still little bit messy for time reasons. Some of the dependencies we can add to base images and remove extra steps.  I also cloned `make-packages.sh` from `msquic` so I can update without waiting for PRs in msquic and PR to suck in changes. I will clean that up after we have ARM tests running. 

This also includes some long needed cleanup in `System.Net.MsQuic.Transport.csproj'. We would always try to build x64 and x86 - even if that is useless for macOS and Linux. (and does not work). It also ignored `Configuration` - creating release binaries in all cases. This now properly respects `Configuration` from pipeline opening path to running stress and tests with debug build of msquic -> to get extra asserts and validation. (not part of this change) 