### PR TITLE
update version to 8.0 in main to distinquish from release/7.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,9 +2,9 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>7.0.0</ProductVersion>
+    <ProductVersion>8.0.0</ProductVersion>
     <!-- File version numbers -->
-    <MajorVersion>7</MajorVersion>
+    <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <!-- Opt-out repo features -->


### PR DESCRIPTION
We branch 7.0 early to contain msquic 2.1. main becomes 8.0 and builds msquic 2.2 