### PR TITLE
update msquic to current main

### DIFF
--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -88,7 +88,7 @@ stages:
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           name: NetCore-Public
-          demands: ImageOverride -equals 1es-ubuntu-1804-open
+          demands: ImageOverride -equals 1es-ubuntu-2004-open
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
@@ -96,7 +96,7 @@ stages:
           demands: ImageOverride -equals build.ubuntu.1804.amd64
       container:
         registry: mcr.microsoft.com/dotnet-buildtools/prereqs
-        image: ubuntu-20.04-cross-arm64
+        image: ubuntu-18.04-cross-arm64
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:
@@ -111,10 +111,10 @@ stages:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.ubuntu.2004.amd64
+          demands: ImageOverride -equals build.ubuntu.1804.amd64
       container:
         registry: mcr.microsoft.com/dotnet-buildtools/prereqs
-        image: ubuntu-20.04-cross-arm
+        image: ubuntu-18.04-cross-arm
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -70,15 +70,15 @@ stages:
       runTests: false
       container: 
         registry: mcr
-        image: ubuntu-18.04
+        image: ubuntu-20.04
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+          demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-20.04'
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:
@@ -93,10 +93,10 @@ stages:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.ubuntu.1804.amd64
+          demands: ImageOverride -equals build.ubuntu.2004.amd64
       container:
         registry: mcr.microsoft.com/dotnet-buildtools/prereqs
-        image: ubuntu-18.04-cross-arm64
+        image: ubuntu-20.04-cross-arm64
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:
@@ -111,10 +111,10 @@ stages:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.ubuntu.1804.amd64
+          demands: ImageOverride -equals build.ubuntu.2004.amd64
       container:
         registry: mcr.microsoft.com/dotnet-buildtools/prereqs
-        image: ubuntu-18.04-cross-arm
+        image: ubuntu-20.04-cross-arm
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -70,15 +70,15 @@ stages:
       runTests: false
       container: 
         registry: mcr
-        image: ubuntu-20.04
+        image: ubuntu-18.04
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          vmImage: 'ubuntu-20.04'
+          vmImage: 'ubuntu-18.04'
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:
@@ -88,12 +88,12 @@ stages:
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           name: NetCore-Public
-          demands: ImageOverride -equals 1es-ubuntu-2004-open
+          demands: ImageOverride -equals 1es-ubuntu-1804-open
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals build.ubuntu.2004.amd64
+          demands: ImageOverride -equals build.ubuntu.1804.amd64
       container:
         registry: mcr.microsoft.com/dotnet-buildtools/prereqs
         image: ubuntu-20.04-cross-arm64

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -74,9 +74,9 @@ jobs:
         - _crossBuild: ''
         - _buildargs: -ci -c $(_BuildConfig) $(_testBuildArg) $(_signingArgs) $(_officialBuildArgs) /p:TargetArchitecture=${{ parameters.archType }}
         - ${{ if eq(parameters.archType, 'arm64') }}:
-          - _crossBuild: CC=clang-10 CXX=clang++-10 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
+          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
         - ${{ if eq(parameters.archType, 'arm') }}:
-          - _crossBuild: CC=clang-10 CXX=clang++-10 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
+          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
 
       steps:
       - checkout: self

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -74,9 +74,9 @@ jobs:
         - _crossBuild: ''
         - _buildargs: -ci -c $(_BuildConfig) $(_testBuildArg) $(_signingArgs) $(_officialBuildArgs) /p:TargetArchitecture=${{ parameters.archType }}
         - ${{ if eq(parameters.archType, 'arm64') }}:
-          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
+          - _crossBuild: CC=clang-10 CXX=clang++-10 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
         - ${{ if eq(parameters.archType, 'arm') }}:
-          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
+          - _crossBuild: CC=clang-10 CXX=clang++-10 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
 
       steps:
       - checkout: self


### PR DESCRIPTION
We locked on msquic  release/2.1 at the end of the .NET 7.0 release. 
This change will allow us to test upcoming 2.2 msquic release. 