### PR TITLE
update windows image names

### DIFF
--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -58,10 +58,10 @@ stages:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+          demands: ImageOverride -equals '1es-windows-2019'
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          vmImage: 'windows-latest'
+          vmImage: '1es-windows-2019'
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -61,7 +61,7 @@ stages:
           demands: ImageOverride -equals '1es-windows-2019'
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          vmImage: '1es-windows-2019'
+          vmImage: '1es-windows-2019-open'
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -61,7 +61,8 @@ stages:
           demands: ImageOverride -equals '1es-windows-2019'
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          vmImage: '1es-windows-2019-open'
+          name: NetCore-Public
+          demands: ImageOverride -equals 1es-windows-2019-open
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:


### PR DESCRIPTION
It seems like the old queue no longer exist
```
##[error]Failed to request agent. Exception Image Build.Windows.10.Amd64.VS2019 doesn't exist in pool NetCore1ESPool-Internal
,##[error]The remote provider was unable to process the request.
```

I change it to next best guess. Keeping both public and internal same so it is easier to test and get consistent results.
