### PR TITLE
update windows queue to match runtime

### DIFF
--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -58,7 +58,7 @@ stages:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals '1es-windows-2019'
+          demands: ImageOverride -equals 'windows.vs2022.amd64'
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           name: NetCore-Public


### PR DESCRIPTION
follow up on  #118
It seems like the queues are still not right. official build fails with 
```
##[error]Failed to request agent. Exception Image '1es-windows-2019' doesn't exist in pool NetCore1ESPool-Internal
,##[error]The remote provider was unable to process the request.
```

I don't know what as https://helix.dot.net/#1ESHostedPoolImagesWestUS-rg-Internal-Windows still shows it.

This change matches what I found in runtime repo. We really should not need anything special. 