### PR TITLE
Delete single quotes around image name

### DIFF
--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -58,7 +58,7 @@ stages:
         isOfficialBuild: true
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 'windows.vs2022.amd64'
+          demands: ImageOverride -equals windows.vs2022.amd64
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
           name: NetCore-Public


### PR DESCRIPTION
Fixes issue noted by @wfurt ; [sample build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2105956&view=logs&j=44ec6876-9b88-5d77-6451-d0463602967d)

```
##[error]Failed to request agent. Exception Image 'windows.vs2022.amd64' doesn't exist in pool NetCore1ESPool-Internal
,##[error]The remote provider was unable to process the request.
```
Not sure if AzDO ever dealt with " / ' correctly