### PR TITLE
add arm64 build

### DIFF
--- a/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
+++ b/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
@@ -29,10 +29,10 @@
 
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\arm64_$(Configuration)_schannel\msquic.dll"
-                PackagePath="runtimes/win10-x64/native/"/>
+                PackagePath="runtimes/win10-arm64/native/"/>
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\arm64_$(Configuration)_schannel\msquic.pdb"
-                PackagePath="runtimes/win10-x64/native/"/>
+                PackagePath="runtimes/win10-arm64/native/"/>
         </ItemGroup>
     </Target>
 

--- a/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
+++ b/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
@@ -26,6 +26,13 @@
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\x64_$(Configuration)_schannel\msquic.pdb"
                 PackagePath="runtimes/win10-x64/native/"/>
+
+            <TfmSpecificPackageFile
+                Include="..\msquic\artifacts\bin\windows\arm64_$(Configuration)_schannel\msquic.dll"
+                PackagePath="runtimes/win10-x64/native/"/>
+            <TfmSpecificPackageFile
+                Include="..\msquic\artifacts\bin\windows\arm64_$(Configuration)_schannel\msquic.pdb"
+                PackagePath="runtimes/win10-x64/native/"/>
         </ItemGroup>
     </Target>
 
@@ -39,6 +46,9 @@
         <!-- Legacy reasons. Should be fixed.  -->
         <Exec
             Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch x86 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
+            WorkingDirectory="../msquic" Condition="'$(TargetOS)' == 'windows'"/>
+        <Exec
+            Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch arm64 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
             WorkingDirectory="../msquic" Condition="'$(TargetOS)' == 'windows'"/>
     </Target>
 </Project>


### PR DESCRIPTION
This adds arm64 windows binaries. I originally tried it as separate pipeline but that has two problems:
- we don't have any machines in pool
- and it complicates packaging as we would need to consolidate artifacts from multiple builds for the final package assembly.

so instead this uses the existing hack for x86 when we simply build all three binaries unconditionally for Windows and we package them into Nuget in single step. 

Since this repro is primarily used as transport I feel this is reasonable compromise. 
if build by developers locally, it will require ARM targets in VS (probably already added to build runtime) 

contributes to https://github.com/dotnet/runtime/issues/82885 
