### PR TITLE
disable debug builds

### DIFF
--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -29,9 +29,6 @@ jobs:
         matrix:
           Release:
             _BuildConfig: Release
-          ${{ if eq(parameters.isOfficialBuild, false) }}:
-            Debug:
-              _BuildConfig: Debug
 
       ${{ if eq(parameters.runTests, true) }}:
         testResultsFormat: vstest


### PR DESCRIPTION
we currently build every platform twice - once as Release and once as Debug. There may be benefits of producing packages that use MsQuic debug build with their Asserts and extra checks. However we currently don't have any way how to consume that so it is pure waste of resources.  With this change we would build only the release versions. 

The can be revisited in future if we work out useful workflow. 