### PR TITLE
paralelize build

### DIFF
--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -66,6 +66,36 @@ stages:
 
   - template: /eng/pipelines/templates/build-job.yml
     parameters:
+      osGroup: Windows
+      archType: x86
+      runTests: false
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        isOfficialBuild: true
+        pool:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals 1es-windows-2019
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        pool:
+          name: NetCore-Public
+          demands: ImageOverride -equals 1es-windows-2019-open
+
+  - template: /eng/pipelines/templates/build-job.yml
+    parameters:
+      osGroup: Windows
+      archType: arm64
+      runTests: false
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        isOfficialBuild: true
+        pool:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals 1es-windows-2019
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        pool:
+          name: NetCore-Public
+          demands: ImageOverride -equals 1es-windows-2019-open
+
+  - template: /eng/pipelines/templates/build-job.yml
+    parameters:
       osGroup: Linux
       archType: x64
       runTests: false

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -4,7 +4,7 @@ parameters:
   archType: ''
   container: ''
   pool: {}
-  isOfficialBuild: false
+  isOfficialBuild: true
   runTests: true
 
 jobs:

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -70,10 +70,11 @@ jobs:
                             /p:DotNetSignType=$(_SignType)
         - _crossBuild: ''
         - _buildargs: -ci -c $(_BuildConfig) $(_testBuildArg) $(_signingArgs) $(_officialBuildArgs) /p:TargetArchitecture=${{ parameters.archType }}
-        - ${{ if eq(parameters.archType, 'arm64') }}:
-          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
-        - ${{ if eq(parameters.archType, 'arm') }}:
-          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
+        - ${{ if eq(parameters.osGroup, 'Linux') }}:
+          - ${{ if eq(parameters.archType, 'arm64') }}:
+            - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
+          - ${{ if eq(parameters.archType, 'arm') }}:
+            - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
 
       steps:
       - checkout: self

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -4,7 +4,7 @@ parameters:
   archType: ''
   container: ''
   pool: {}
-  isOfficialBuild: true
+  isOfficialBuild: false
   runTests: true
 
 jobs:

--- a/global.json
+++ b/global.json
@@ -8,6 +8,7 @@
     "dotnet": "8.0.100-preview.1.23115.2"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23123.2"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23123.2",
+    "Microsoft.Build.NoTargets": "3.7.0"
   }
 }

--- a/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
+++ b/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
@@ -7,6 +7,7 @@
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     </PropertyGroup>
 
+<!--
     <PropertyGroup>
         <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore</TargetsForTfmSpecificContentInPackage>
     </PropertyGroup>
@@ -33,22 +34,37 @@
             <TfmSpecificPackageFile
                 Include="..\msquic\artifacts\bin\windows\arm64_$(Configuration)_schannel\msquic.pdb"
                 PackagePath="runtimes/win10-arm64/native/"/>
+
+            <TfmSpecificPackageFile
+                Include="..\msquic\artifacts\bin\macos\x64_$(Configuration)_openssl\libmsquic.2.dylib"
+                PackagePath="runtimes/osx-x64/native/"/>
         </ItemGroup>
     </Target>
+-->
+
+  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <!-- Just reference the runtime packages but don't build them in order to avoid unintentional Build/Pack invocations. -->
+    <ProjectReference Include="pkg\runtime.native.$(MSBuildProjectName).proj" BuildReference="false" />
+    <!-- Make the runtime specific packages non transitive so that they aren't flowing into other projects. -->
+    <ProjectReference Include="pkg\runtime.*.runtime.native.$(MSBuildProjectName).proj" BuildReference="false" PrivateAssets="all" />
+  </ItemGroup>
 
     <PropertyGroup>
     <ExtraMsquicArgs Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">-SysRoot /crossrootfs/$(TargetArchitecture)</ExtraMsquicArgs>
     </PropertyGroup>
+
     <Target Name="Build-native" AfterTargets="Build">
         <Exec IgnoreStandardErrorWarningFormat="true"
             Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch $(TargetArchitecture) $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
             WorkingDirectory="../msquic"/>
         <!-- Legacy reasons. Should be fixed.  -->
+        <!--
         <Exec
             Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch x86 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
             WorkingDirectory="../msquic" Condition="'$(TargetOS)' == 'windows'"/>
         <Exec
             Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch arm64 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
             WorkingDirectory="../msquic" Condition="'$(TargetOS)' == 'windows'"/>
+        -->
     </Target>
 </Project>

--- a/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
+++ b/src/System.Net.MsQuic.Transport/System.Net.MsQuic.Transport.csproj
@@ -7,47 +7,12 @@
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     </PropertyGroup>
 
-<!--
-    <PropertyGroup>
-        <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddBuildOutputToPackageCore</TargetsForTfmSpecificContentInPackage>
-    </PropertyGroup>
-
-    <Target Name="_AddBuildOutputToPackageCore" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-        <ItemGroup>
-            <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x86_$(Configuration)_schannel\msquic.dll"
-                PackagePath="runtimes/win10-x86/native/"/>
-            <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x86_$(Configuration)_schannel\msquic.pdb"
-                PackagePath="runtimes/win10-x86/native/"/>
-
-            <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x64_$(Configuration)_schannel\msquic.dll"
-                PackagePath="runtimes/win10-x64/native/"/>
-            <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\x64_$(Configuration)_schannel\msquic.pdb"
-                PackagePath="runtimes/win10-x64/native/"/>
-
-            <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\arm64_$(Configuration)_schannel\msquic.dll"
-                PackagePath="runtimes/win10-arm64/native/"/>
-            <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\windows\arm64_$(Configuration)_schannel\msquic.pdb"
-                PackagePath="runtimes/win10-arm64/native/"/>
-
-            <TfmSpecificPackageFile
-                Include="..\msquic\artifacts\bin\macos\x64_$(Configuration)_openssl\libmsquic.2.dylib"
-                PackagePath="runtimes/osx-x64/native/"/>
-        </ItemGroup>
-    </Target>
--->
-
-  <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <!-- Just reference the runtime packages but don't build them in order to avoid unintentional Build/Pack invocations. -->
-    <ProjectReference Include="pkg\runtime.native.$(MSBuildProjectName).proj" BuildReference="false" />
-    <!-- Make the runtime specific packages non transitive so that they aren't flowing into other projects. -->
-    <ProjectReference Include="pkg\runtime.*.runtime.native.$(MSBuildProjectName).proj" BuildReference="false" PrivateAssets="all" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+        <!-- Just reference the runtime packages but don't build them in order to avoid unintentional Build/Pack invocations. -->
+        <ProjectReference Include="pkg\runtime.native.$(MSBuildProjectName).proj" BuildReference="false" />
+        <!-- Make the runtime specific packages non transitive so that they aren't flowing into other projects. -->
+        <ProjectReference Include="pkg\runtime.*.runtime.native.$(MSBuildProjectName).proj" BuildReference="false" PrivateAssets="all" />
+    </ItemGroup>
 
     <PropertyGroup>
     <ExtraMsquicArgs Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'">-SysRoot /crossrootfs/$(TargetArchitecture)</ExtraMsquicArgs>
@@ -57,14 +22,5 @@
         <Exec IgnoreStandardErrorWarningFormat="true"
             Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch $(TargetArchitecture) $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
             WorkingDirectory="../msquic"/>
-        <!-- Legacy reasons. Should be fixed.  -->
-        <!--
-        <Exec
-            Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch x86 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
-            WorkingDirectory="../msquic" Condition="'$(TargetOS)' == 'windows'"/>
-        <Exec
-            Command="pwsh scripts/build.ps1 -Config $(Configuration) -Arch arm64 $(ExtraMsquicArgs) -UseSystemOpenSSLCrypto -DisableTools -DisableTest -DisablePerf"
-            WorkingDirectory="../msquic" Condition="'$(TargetOS)' == 'windows'"/>
-        -->
     </Target>
 </Project>

--- a/src/System.Net.MsQuic.Transport/pkg/runtime.native.System.Net.MsQuic.Transport.proj
+++ b/src/System.Net.MsQuic.Transport/pkg/runtime.native.System.Net.MsQuic.Transport.proj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <!-- Reference the outputs for the dependency nodes calculation. -->
+    <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
+    <!-- This is a meta package and doesn't contain any libs. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Listing the runtime specific packages to populate the dependencies section.
+         Not building these references to avoid unintentional Build/Pack invocations.
+         They are filtered in the traversal build in oob-all.csproj based on the OutputRid. -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*.proj" Exclude="$(MSBuildProjectFile)" BuildReference="false" />
+  </ItemGroup>
+</Project>

--- a/src/System.Net.MsQuic.Transport/pkg/runtime.native.System.Net.MsQuic.Transport.props
+++ b/src/System.Net.MsQuic.Transport/pkg/runtime.native.System.Net.MsQuic.Transport.props
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <!-- IncludeBuildOutput needs to be set to true to make NuGet include the passed in debug symbol files. -->
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <IsPackable>true</IsPackable>
+    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(SymbolsSuffix)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    <!-- When KeepNativeSymbols is set, debug symbols are kept in the .so files.  Separate symbol files do not exist that need to be packed. -->
+    <TargetsForTfmSpecificDebugSymbolsInPackage Condition="'$(KeepNativeSymbols)' != 'true'">$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificNativeSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
+    <UseRuntimePackageDisclaimer>true</UseRuntimePackageDisclaimer>
+    <!-- This is a native package and doesn't contain any ref/lib assets. -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(NativeBinDir)$(LibPrefix)System.IO.Ports.Native$(LibSuffix)"
+          PackagePath="runtimes/$(OutputRid)/native"
+          Pack="true" />
+  </ItemGroup>
+
+  <Target Name="AddRuntimeSpecificNativeSymbolToPackage">
+    <ItemGroup>
+      <TfmSpecificDebugSymbolsFile Include="$(NativeBinDir)$(LibPrefix)System.IO.Ports.Native$(LibSuffix)$(SymbolsSuffix)"
+                                   TargetPath="/runtimes/$(OutputRid)/native"
+                                   TargetFramework="$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/System.Net.MsQuic.Transport/pkg/runtime.native.System.Net.MsQuic.Transport.props
+++ b/src/System.Net.MsQuic.Transport/pkg/runtime.native.System.Net.MsQuic.Transport.props
@@ -14,14 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(NativeBinDir)$(LibPrefix)System.IO.Ports.Native$(LibSuffix)"
+    <None Include="$(NativeBinDir)$(LibPrefix)System.Net.MsQuic.Transport.Native$(LibSuffix)"
           PackagePath="runtimes/$(OutputRid)/native"
           Pack="true" />
   </ItemGroup>
 
   <Target Name="AddRuntimeSpecificNativeSymbolToPackage">
     <ItemGroup>
-      <TfmSpecificDebugSymbolsFile Include="$(NativeBinDir)$(LibPrefix)System.IO.Ports.Native$(LibSuffix)$(SymbolsSuffix)"
+      <TfmSpecificDebugSymbolsFile Include="$(NativeBinDir)$(LibPrefix)System.Net.MsQuic.Transport.Native$(LibSuffix)$(SymbolsSuffix)"
                                    TargetPath="/runtimes/$(OutputRid)/native"
                                    TargetFramework="$(TargetFramework)" />
     </ItemGroup>

--- a/src/System.Net.MsQuic.Transport/pkg/runtime.win-arm64.runtime.native.System.Net.MsQuic.Transport.proj
+++ b/src/System.Net.MsQuic.Transport/pkg/runtime.win-arm64.runtime.native.System.Net.MsQuic.Transport.proj
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="runtime.native.System.Net.MsQuic.Transport.props" />
+  <PropertyGroup>
+    <!-- This is a native package, where package baseline validation doesn't really make much sense -->
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+</Project>

--- a/src/System.Net.MsQuic.Transport/pkg/runtime.win-x64.runtime.native.System.Net.MsQuic.Transport.proj
+++ b/src/System.Net.MsQuic.Transport/pkg/runtime.win-x64.runtime.native.System.Net.MsQuic.Transport.proj
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="runtime.native.System.Net.MsQuic.Transport.props" />
+  <PropertyGroup>
+    <!-- This is a native package, where package baseline validation doesn't really make much sense -->
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+</Project>

--- a/src/System.Net.MsQuic.Transport/pkg/runtime.win-x86.runtime.native.System.Net.MsQuic.Transport.proj
+++ b/src/System.Net.MsQuic.Transport/pkg/runtime.win-x86.runtime.native.System.Net.MsQuic.Transport.proj
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="runtime.native.System.Net.MsQuic.Transport.props" />
+  <PropertyGroup>
+    <!-- This is a native package, where package baseline validation doesn't really make much sense -->
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This is attempt to make the build more similar to `runtime`. Artifacts are build in each individual leg per OS/architecture and then final NuGet is constructed at the end. This should hopefully make the build faster and easier to maintain. The biggest benefit is that we could flow binaries for OSes other than Windows to runtime. That could possibly allow to run tests on macOS or distribute specific MsQuic version to all Linux instances - either via inclusion in Debug builds or via special test assets. 

I took this from System.IO.Ports but I was not able to trigger the signing and publishing phase on public CI pipeline. 
So this is somewhat experimental and it can destabilize the build flow for some time. 
Even with that I'm proposing to give it trey and we can either roll it back if needed (e.g. have urgency to pick up more MsQuic changes) or do follow-up changes to make it work. 
(perhaps after #134 is merged and we have updated package for runtime) 
 