### PR TITLE
Fix official build

### DIFF
--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -154,7 +154,7 @@ stages:
       archType: x64
       runTests: false
       pool:
-        vmImage: 'macOS-10.15'
+        vmImage: 'macOS-11'
 
  # Publish and validation steps. Only run in official builds
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -155,11 +155,26 @@ stages:
       pool:
         vmImage: 'macOS-10.15'
 
-# Publish and validation steps. Only run in official builds
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: \eng\common\templates\post-build\post-build.yml
+  - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
-      publishingInfraVersion: 3
-      validateDependsOn:
-        - build
-      enableSourceLinkValidation: true
+      configuration: Release
+      dependsOn: Sign_Package_Publish
+      publishUsingPipelines: true
+      pool:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals windows.vs2022.amd64
+
+ # Publish and validation steps. Only run in official builds
+ - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - stage: Publish
+    dependsOn:
+    - Build
+    jobs:
+    - template: /eng/common/templates/job/publish-build-assets.yml
+      parameters:
+        publishUsingPipelines: true
+        publishAssetsImmediately: true
+        pool:
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals windows.vs2022.amd64

--- a/eng/pipelines/msquic.yml
+++ b/eng/pipelines/msquic.yml
@@ -44,6 +44,7 @@ pr:
 variables:
   - name: _TeamName
     value: dotnet-core
+  - template: /eng/common/templates/variables/pool-providers.yml
 
 stages:
 - stage: build
@@ -57,11 +58,11 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals 1es-windows-2019
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-windows-2019-open
 
   - template: /eng/pipelines/templates/build-job.yml
@@ -72,11 +73,11 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals 1es-windows-2019
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-windows-2019-open
 
   - template: /eng/pipelines/templates/build-job.yml
@@ -87,11 +88,11 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals 1es-windows-2019
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-windows-2019-open
 
   - template: /eng/pipelines/templates/build-job.yml
@@ -105,7 +106,7 @@ stages:
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
@@ -118,12 +119,12 @@ stages:
       runTests: false
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-ubuntu-2004-open
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals build.ubuntu.1804.amd64
       container:
         registry: mcr.microsoft.com/dotnet-buildtools/prereqs
@@ -136,12 +137,12 @@ stages:
       runTests: false
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         pool:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-ubuntu-2004-open
       ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         isOfficialBuild: true
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals build.ubuntu.1804.amd64
       container:
         registry: mcr.microsoft.com/dotnet-buildtools/prereqs
@@ -155,17 +156,8 @@ stages:
       pool:
         vmImage: 'macOS-10.15'
 
-  - template: /eng/common/templates/job/publish-build-assets.yml
-    parameters:
-      configuration: Release
-      dependsOn: Sign_Package_Publish
-      publishUsingPipelines: true
-      pool:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals windows.vs2022.amd64
-
  # Publish and validation steps. Only run in official builds
- - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish
     dependsOn:
     - Build

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -9,13 +9,13 @@ parameters:
 
 jobs:
 
-- template: /eng/common/templates/jobs/jobs.yml
+- template: /eng/common/templates/job/job.yml
   parameters:
     enableTelemetry: true
     helixRepo: dotnet/msquic
     pool: ${{ parameters.pool }}
     enablePublishBuildArtifacts: true
-    enablePublishBuildAssets: ${{ eq(parameters.osGroup, 'Windows') }}
+    enablePublishBuildAssets: ${{ parameters.isOfficialBuild }}
     enablePublishUsingPipelines: true
     enableMicrobuild: true
     graphFileGeneration:

--- a/eng/pipelines/templates/build-job.yml
+++ b/eng/pipelines/templates/build-job.yml
@@ -18,88 +18,84 @@ jobs:
     enablePublishBuildAssets: ${{ parameters.isOfficialBuild }}
     enablePublishUsingPipelines: true
     enableMicrobuild: true
-    graphFileGeneration:
-      enabled: false
-      includeToolset: false
 
-    jobs:
-    - job: ${{ format('{0}_{1}', parameters.osGroup, parameters.archType) }}
-      displayName: ${{ format('{0} {1}', parameters.osGroup, parameters.archType) }}
-      strategy:
-        matrix:
-          Release:
-            _BuildConfig: Release
+    name: ${{ format('{0}_{1}', parameters.osGroup, parameters.archType) }}
+    displayName: ${{ format('{0} {1}', parameters.osGroup, parameters.archType) }}
+    strategy:
+      matrix:
+        Release:
+          _BuildConfig: Release
 
-      ${{ if eq(parameters.runTests, true) }}:
-        testResultsFormat: vstest
-        testRunTitle: ${{ parameters.osGroup }}_${{ parameters.archType }}_$(_BuildConfig)
+    ${{ if eq(parameters.runTests, true) }}:
+      testResultsFormat: vstest
+      testRunTitle: ${{ parameters.osGroup }}_${{ parameters.archType }}_$(_BuildConfig)
 
-      ${{ if ne(parameters.container, '') }}:
-        ${{ if eq(parameters.container.registry, 'mcr') }}:
-          container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container.image) }}
-        ${{ if ne(parameters.container.registry, 'mcr') }}:
-          container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
+    ${{ if ne(parameters.container, '') }}:
+      ${{ if eq(parameters.container.registry, 'mcr') }}:
+        container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container.image) }}
+      ${{ if ne(parameters.container.registry, 'mcr') }}:
+        container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
 
-      variables:
-        - _buildScript: build.cmd
-
-        - ${{ if ne(parameters.osGroup, 'Windows') }}:
-          - _buildScript: ./build.sh
-          - _outputPath: $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.osGroup }}/${{ parameters.archType }}_$(_BuildConfig)_openssl
-
-        - ${{ if eq(parameters.osGroup, 'macOS') }}:
-          - OPENSSL_ROOT_DIR: /usr/local/opt/openssl@1.1
-
-        - _testBuildArg: ''
-        - ${{ if eq(parameters.runTests, true) }}:
-          - _testBuildArg: -test
-
-        - _officialBuildArgs: ''
-        - _signingArgs: ''
-        - ${{ if eq(parameters.isOfficialBuild, true) }}:
-          - group: DotNet-Symbol-Server-Pats
-          - _SignType: real
-          - _officialBuildArgs: -publish
-                                /p:TeamName=$(_TeamName)
-                                /p:OfficialBuildId=$(Build.BuildNumber)
-                                /p:DotNetPublishUsingPipelines=true
-                                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-          - ${{ if eq(parameters.osGroup, 'Windows') }}:
-            - _signingArgs: -sign
-                            /p:DotNetSignType=$(_SignType)
-        - _crossBuild: ''
-        - _buildargs: -ci -c $(_BuildConfig) $(_testBuildArg) $(_signingArgs) $(_officialBuildArgs) /p:TargetArchitecture=${{ parameters.archType }}
-        - ${{ if eq(parameters.osGroup, 'Linux') }}:
-          - ${{ if eq(parameters.archType, 'arm64') }}:
-            - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
-          - ${{ if eq(parameters.archType, 'arm') }}:
-            - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
-
-      steps:
-      - checkout: self
-        submodules: recursive
-
-      - ${{ if eq(parameters.osGroup, 'Windows') }}:
-        - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
-          displayName: Install native dependencies
-
-      - ${{ if eq(parameters.osGroup, 'macOS') }}:
-        - script: sudo gem install fpm
-          displayName: Install fpm
-
-      - script: $(_crossBuild) $(_buildScript) $(_buildargs)
-        displayName: Build binaries
+    variables:
+      - _buildScript: build.cmd
 
       - ${{ if ne(parameters.osGroup, 'Windows') }}:
-        - script: ./scripts/make-packages.sh -arch ${{ parameters.archType }} -config $(_BuildConfig) -output $(_outputPath)
-          displayName: Make Unix packages
-          workingDirectory: src/msquic
+        - _buildScript: ./build.sh
+        - _outputPath: $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.osGroup }}/${{ parameters.archType }}_$(_BuildConfig)_openssl
 
-        - task: PublishBuildArtifacts@1
-          displayName: Push Unix Packages
-          inputs:
-            PathtoPublish: $(_outputPath)
-            PublishLocation: Container
-            ArtifactName: UnsignedUnixPackages
-          condition: succeeded()
+      - ${{ if eq(parameters.osGroup, 'macOS') }}:
+        - OPENSSL_ROOT_DIR: /usr/local/opt/openssl@1.1
+
+      - _testBuildArg: ''
+      - ${{ if eq(parameters.runTests, true) }}:
+        - _testBuildArg: -test
+
+      - _officialBuildArgs: ''
+      - _signingArgs: ''
+      - ${{ if eq(parameters.isOfficialBuild, true) }}:
+        - group: DotNet-Symbol-Server-Pats
+        - _SignType: real
+        - _officialBuildArgs: -publish
+                              /p:TeamName=$(_TeamName)
+                              /p:OfficialBuildId=$(Build.BuildNumber)
+                              /p:DotNetPublishUsingPipelines=true
+                              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+        - ${{ if eq(parameters.osGroup, 'Windows') }}:
+          - _signingArgs: -sign
+                          /p:DotNetSignType=$(_SignType)
+      - _crossBuild: ''
+      - _buildargs: -ci -c $(_BuildConfig) $(_testBuildArg) $(_signingArgs) $(_officialBuildArgs) /p:TargetArchitecture=${{ parameters.archType }}
+      - ${{ if eq(parameters.osGroup, 'Linux') }}:
+        - ${{ if eq(parameters.archType, 'arm64') }}:
+          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=aarch64-linux-gnu --sysroot=/crossrootfs/arm64" LDFLAGS='-L/crossrootfs/arm64/lib -L/crossrootfs/arm64/usr/lib/aarch64-linux-gnu'
+        - ${{ if eq(parameters.archType, 'arm') }}:
+          - _crossBuild: CC=clang-9 CXX=clang++-9 CFLAGS="--target=arm-linux-gnueabihf --sysroot=/crossrootfs/arm" LDFLAGS='-L/crossrootfs/arm/lib -L/crossrootfs/arm/usr/lib/arm-linux-gnueabihf'
+
+    steps:
+    - checkout: self
+      submodules: recursive
+
+    - ${{ if eq(parameters.osGroup, 'Windows') }}:
+      - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
+        displayName: Install native dependencies
+
+    - ${{ if eq(parameters.osGroup, 'macOS') }}:
+      - script: sudo gem install fpm
+        displayName: Install fpm
+
+    - script: $(_crossBuild) $(_buildScript) $(_buildargs)
+      displayName: Build binaries
+
+    - ${{ if ne(parameters.osGroup, 'Windows') }}:
+      - script: ./scripts/make-packages.sh -arch ${{ parameters.archType }} -config $(_BuildConfig) -output $(_outputPath)
+        displayName: Make Unix packages
+        workingDirectory: src/msquic
+
+      - task: PublishBuildArtifacts@1
+        displayName: Push Unix Packages
+        inputs:
+          PathtoPublish: $(_outputPath)
+          PublishLocation: Container
+          ArtifactName: UnsignedUnixPackages
+        condition: succeeded()


### PR DESCRIPTION
- Fence publishing in separate stage
- Fix yml and use pool provider subs
- Fix parameter lowering

This still doesn't fix the fact that's nothing is getting packaged. That requires:
- Only one job creates the metapackage that references the others.
- Each leg packs its rid specific assets.

Right now there's only a reference to the csproj from Build.props, and that one doesn't pack dependents. There's no reference to the subprojects in the proper places.