### PR TITLE
Add CodeQL exclusions for submodules

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -1,0 +1,9 @@
+# This file configures CodeQL runs and TSA bug autofiling. For more information, see:
+# https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
+# (Access restricted to Microsoft employees only.)
+
+path_classifiers:
+  submodules:
+    # Submodules are analyzed within their primary repos and should not be analyzed
+    # as part of building this repo.
+    - src/msquic


### PR DESCRIPTION
This avoids duplicative CodeQL alerts from appearing in our reporting dashboard.