### PR TITLE
Fix git clone command in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains sources for the MsQuic private transport package which lights
 
 ## Building
 
-- Clone the repo recursively (`git clone --recursively`) or run `git submodule update --init --recursive` to get all the submodules.
+- Clone the repo recursively (`git clone --recursive`) or run `git submodule update --init --recursive` to get all the submodules.
 - Run `build.cmd`
 
 ## .NET Foundation


### PR DESCRIPTION
There is no `ly` on the end of the `--recursive` argument. I would cite [the documentation for `git clone`](https://git-scm.com/docs/git-clone), but this argument is not documented there. I did confirm it works on my machine with Git 2.44.